### PR TITLE
feat(add-todo-item): implement TodoList core module

### DIFF
--- a/src/TodoList.js
+++ b/src/TodoList.js
@@ -1,0 +1,46 @@
+/**
+ * 簡易 TodoList — 記憶體版
+ * 支援 add / list / complete / remove，每筆 id 自動遞增
+ */
+class TodoList {
+  constructor() {
+    this._items = []
+    this._nextId = 1
+  }
+
+  /** 新增 todo，回傳 { id, title, completed: false } */
+  add(title) {
+    const item = { id: this._nextId++, title, completed: false }
+    this._items.push(item)
+    return { ...item }
+  }
+
+  /** 回傳目前所有 todo（淺拷貝） */
+  list() {
+    return this._items.map(i => ({ ...i }))
+  }
+
+  /** 標記指定 id 為完成，不存在拋 Error */
+  complete(id) {
+    const item = this._find(id)
+    item.completed = true
+    return { ...item }
+  }
+
+  /** 刪除指定 id，不存在拋 Error，成功回傳 true */
+  remove(id) {
+    const idx = this._items.findIndex(i => i.id === id)
+    if (idx === -1) throw new Error('Todo not found')
+    this._items.splice(idx, 1)
+    return true
+  }
+
+  /** @private */
+  _find(id) {
+    const item = this._items.find(i => i.id === id)
+    if (!item) throw new Error('Todo not found')
+    return item
+  }
+}
+
+module.exports = TodoList

--- a/src/__tests__/TodoList.test.js
+++ b/src/__tests__/TodoList.test.js
@@ -1,0 +1,59 @@
+const TodoList = require('../TodoList')
+
+describe('TodoList', () => {
+  let list
+
+  beforeEach(() => {
+    list = new TodoList()
+  })
+
+  // R1 + Scenario 1
+  test('add() 回傳含 id/title/completed 的物件', () => {
+    const item = list.add('買牛奶')
+    expect(item).toEqual({ id: 1, title: '買牛奶', completed: false })
+  })
+
+  // R4 + Scenario 1
+  test('list() 回傳所有 todo 陣列', () => {
+    list.add('買牛奶')
+    list.add('運動')
+    expect(list.list()).toHaveLength(2)
+    expect(list.list()[0].title).toBe('買牛奶')
+  })
+
+  // R2 + Scenario 2
+  test('complete(id) 標記 completed=true', () => {
+    list.add('買牛奶')
+    const updated = list.complete(1)
+    expect(updated.completed).toBe(true)
+    expect(list.list()[0].completed).toBe(true)
+  })
+
+  // R3 + Scenario 3
+  test('remove(id) 刪除 todo 並回傳 true', () => {
+    list.add('買牛奶')
+    const result = list.remove(1)
+    expect(result).toBe(true)
+    expect(list.list()).toHaveLength(0)
+  })
+
+  // R7 + Scenario 4
+  test('id 自動遞增且唯一', () => {
+    const a = list.add('A')
+    const b = list.add('B')
+    const c = list.add('C')
+    expect(a.id).toBe(1)
+    expect(b.id).toBe(2)
+    expect(c.id).toBe(3)
+  })
+
+  // R5 + Scenario 5
+  test('complete(不存在的id) 拋出 Error', () => {
+    expect(() => list.complete(999)).toThrow('Todo not found')
+  })
+
+  // R6 + Scenario 6
+  test('remove(不存在的id) 拋出 Error', () => {
+    expect(() => list.remove(999)).toThrow('Todo not found')
+  })
+})


### PR DESCRIPTION
## Summary

Implements the `TodoList` core module as specified in Issue #1.

### What changed
- `src/TodoList.js` — new class with `add()`, `list()`, `complete()`, `remove()`
- `src/__tests__/TodoList.test.js` — 7 tests covering all Requirements and Acceptance Scenarios

### Spec compliance
| Requirement | Status |
|---|---|
| R1: add() returns {id, title, completed:false} | ✅ |
| R2: complete(id) marks completed=true | ✅ |
| R3: remove(id) returns true | ✅ |
| R4: list() returns all todos | ✅ |
| R5: complete(missing id) throws Error | ✅ |
| R6: remove(missing id) throws Error | ✅ |
| R7: id is unique auto-increment | ✅ |

### Test results
7/7 passing ✅

Closes #1
