### PR TITLE
feat: add listByStatus to filter todos by completion status

### DIFF
--- a/src/TodoList.js
+++ b/src/TodoList.js
@@ -1,6 +1,6 @@
 /**
  * 簡易 TodoList — 記憶體版
- * 支援 add / list / complete / remove，每筆 id 自動遞增
+ * 支援 add / list / complete / remove / listByStatus，每筆 id 自動遞增
  */
 class TodoList {
   constructor() {
@@ -33,6 +33,20 @@ class TodoList {
     if (idx === -1) throw new Error('Todo not found')
     this._items.splice(idx, 1)
     return true
+  }
+
+  /**
+   * 依完成狀態篩選 todo（淺拷貝）
+   * @param {boolean} completed - true 回傳已完成，false 回傳未完成
+   * @returns {Array}
+   */
+  listByStatus(completed) {
+    if (typeof completed !== 'boolean') {
+      throw new Error('completed must be a boolean')
+    }
+    return this._items
+      .filter(i => i.completed === completed)
+      .map(i => ({ ...i }))
   }
 
   /** @private */

--- a/src/__tests__/TodoList.test.js
+++ b/src/__tests__/TodoList.test.js
@@ -56,4 +56,49 @@ describe('TodoList', () => {
   test('remove(不存在的id) 拋出 Error', () => {
     expect(() => list.remove(999)).toThrow('Todo not found')
   })
+
+  // ===== filter-todos: listByStatus =====
+
+  // R1 + Scenario 1: listByStatus(false) 回傳未完成
+  test('listByStatus(false) 回傳所有 completed=false 的 todo', () => {
+    list.add('買牛奶')
+    list.add('運動')
+    list.add('看書')
+    list.complete(1)
+    const result = list.listByStatus(false)
+    expect(result).toHaveLength(2)
+    expect(result.every(i => i.completed === false)).toBe(true)
+  })
+
+  // R2 + Scenario 2: listByStatus(true) 回傳已完成
+  test('listByStatus(true) 回傳所有 completed=true 的 todo', () => {
+    list.add('買牛奶')
+    list.add('運動')
+    list.add('看書')
+    list.complete(1)
+    const result = list.listByStatus(true)
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe(1)
+    expect(result[0].completed).toBe(true)
+  })
+
+  // R4 + Scenario 3: 空陣列回傳 []
+  test('listByStatus(false) 在空 list 時回傳 []', () => {
+    expect(list.listByStatus(false)).toEqual([])
+  })
+
+  // R3 + Scenario 4: 非 boolean 拋出 Error
+  test('listByStatus(非boolean) 拋出 Error', () => {
+    expect(() => list.listByStatus('done')).toThrow('completed must be a boolean')
+    expect(() => list.listByStatus(1)).toThrow('completed must be a boolean')
+    expect(() => list.listByStatus(null)).toThrow('completed must be a boolean')
+  })
+
+  // R5: 回傳淺拷貝，不影響內部狀態
+  test('listByStatus 回傳淺拷貝，修改不影響內部', () => {
+    list.add('買牛奶')
+    const result = list.listByStatus(false)
+    result[0].title = 'HACKED'
+    expect(list.list()[0].title).toBe('買牛奶')
+  })
 })


### PR DESCRIPTION
## 目的
TodoList.list() 目前回傳所有項目，沒有辦法只看「待完成」或「已完成」的 todo，使用者每次都要自己在外部 filter，重複邏輯散落各處。

加入 `listByStatus(completed)` 方法，傳入 boolean 篩選 todo，統一 filter 邏輯。

## 做了什麼
在現有 `_items` 陣列上加 `filter + map` 方法，不改動 add/complete/remove 介面。加入嚴格 type guard（`typeof completed !== 'boolean'`）處理非 boolean 輸入。

## 驗收條件
- [x] R1: `listByStatus(false)` 回傳所有 completed === false 的 todo 陣列
- [x] R2: `listByStatus(true)` 回傳所有 completed === true 的 todo 陣列
- [x] R3: 傳入非 boolean 值時拋出 `Error('completed must be a boolean')`
- [x] R4: 結果為空時回傳空陣列 `[]`，不拋出錯誤
- [x] R5: 回傳值為淺拷貝，不影響內部狀態

## Acceptance scenarios
- Scenario 1 — 篩選未完成：3 筆 todo，1 筆已完成，listByStatus(false) 回傳 2 筆
- Scenario 2 — 篩選已完成：3 筆 todo，1 筆已完成，listByStatus(true) 回傳 1 筆
- Scenario 3 — 空陣列：空 TodoList，listByStatus(false) 回傳 []
- Scenario 4 — 非 boolean：listByStatus('done') 拋出 Error

## 測試方式
- [x] 所有 spec 需求逐條確認（12/12 tests passing）
- [x] Acceptance scenarios 走過
- [x] Edge case 確認（undefined, NaN, {}, [], 0, 1, null）
- [x] `git diff` 乾淨（無 debug log / TODO / 死 code）

## 相關連結
Closes #3
Spec: `.myspec/active/filter-todos/spec.md`
